### PR TITLE
Resolved legacy registry error by pointing to official jenkins image

### DIFF
--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Container is running
   docker:
     name: jenkins
-    image: vfarcic/jenkins
+    image: jenkins
     ports: 8080:8080
     volumes:
       - "{{ jenkins_base_dir }}:/jenkins"


### PR DESCRIPTION
Hi Viktor,

Awesome job on the docker-swarm tutorial. I'm pretty new to containers and your blog posts are super helpful.  On docker-swarm, during vagrant up, I got "docker.io/vfarcic/jenkins: this image was pulled from a legacy registry." and was able to fix it by switching it to the official image.  I don't know how different your image is, but this allowed me to continue your tutorial through the end of Part 1/4.  Hope this helps.
