### PR TITLE
Adding support for linked clones

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant"
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024
+    v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
   end
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.define "swarm-master" do |node|


### PR DESCRIPTION
Adding support for linked clones in VirtualBox and VMWare. This support was added to vagrant in version 1.8. 

From my testing under VirtualBox 5.0.14 on OS X El Capitan, this changes disk usage from ~9.5GB to ~1.4GB, and also launches the swarm VMs faster as the vbox image does not need to be re-copied for each VM.
