### PR TITLE
Fixed 2 blocking issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 .vagrant
+*.retry

--- a/ansible/library/consul_kv.py
+++ b/ansible/library/consul_kv.py
@@ -21,6 +21,7 @@
 import base64
 import json
 import string
+import urllib
 
 from collections import OrderedDict
 

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -2,13 +2,28 @@
   file:
     path: /data/jenkins/slaves/cd
     state: directory
+    owner: 1000 # uid=1000, mapping to user 'jenkins' inside the jenkins container
+    group: 1000 # gid=1000, mapping to group 'jenkins' inside the jenkins container
     mode: 0777
+  tags: [jenkins]
+
+- name: Jenkins job base directories are present
+  file:
+    path: '{{ item }}'
+    state: directory
+    owner: 1000 # uid=1000, mapping to user 'jenkins' inside the jenkins container
+    group: 1000 # gid=1000, mapping to group 'jenkins' inside the jenkins container
+  with_items:
+    - "{{ jenkins_base_dir }}"
+    - "{{ jenkins_base_dir }}/jobs"
   tags: [jenkins]
 
 - name: Job directories are present
   file:
     path: '{{ jenkins_base_dir }}/jobs/{{ item.dest }}'
     state: directory
+    owner: 1000 # uid=1000, mapping to user 'jenkins' inside the jenkins container
+    group: 1000 # gid=1000, mapping to group 'jenkins' inside the jenkins container
   with_items: jenkins_jobs
   tags: [jenkins]
 
@@ -16,6 +31,8 @@
   template:
     src: '{{ item.src }}'
     dest: '{{ jenkins_base_dir }}/jobs/{{ item.dest }}/config.xml'
+    owner: 1000 # uid=1000, mapping to user 'jenkins' inside the jenkins container
+    group: 1000 # gid=1000, mapping to group 'jenkins' inside the jenkins container
     backup: yes
   with_items: jenkins_jobs
   tags: [jenkins]


### PR DESCRIPTION
Issue #1: the missing 'urllib' import prevents Ansible from deploying services.

Issue #2: the `root:root` ownership of files injected in `/var/jenkins_home` prevents Jenkins from running properly, like reading the injected config or creating new projects.
